### PR TITLE
fix sabdboxServer.runGame function not returning errorMessage

### DIFF
--- a/server/services/sandboxService.coffee
+++ b/server/services/sandboxService.coffee
@@ -136,7 +136,7 @@ module.exports = ($) ->
 
 		loop
 			if verdictData.event == 'error'
-				verdictHistory.push {action: 'error', errorMessage: "Verdict error: #{errorMessage}"}
+				verdictHistory.push {action: 'error', errorMessage: "Verdict error: #{verdictData.errorMessage}"}
 				break
 			else if verdictData.event == 'exit'
 				verdictHistory.push {action: 'error', errorMessage: "Verdict exit with code [#{verdictData.exitCode}]"}
@@ -173,7 +173,6 @@ module.exports = ($) ->
 
 		players = _.map playerConfigs, (config) ->
 			new GameEntity config.cmd
-
 		self.runGame players, verdict, verdictConfig.timeLimit
 			.then (verdictHistory) ->
 				_.invoke players.concat(verdict), 'exit'


### PR DESCRIPTION
```verdictData.errorMessage``` is mistyped as ```errorMessage```, I fixed the error.

btw. Now I saw this error when submitting code at client-side, coming from the verdict (or from the sandbox? I'm not sure.): 

```
"Verdict error: /vol/verdict:2 import json ^^^^^^ SyntaxError: Unexpected reserved word at exports.runInThisContext (vm.js:53:16) at Module._compile (module.js:414:25) at Object.Module._extensions..js (module.js:442:10) at Module.load (module.js:356:32) at Function.Module._load (module.js:313:12) at Function.Module.runMain (module.js:467:10) at startup (node.js:136:18) at node.js:963:3 "
```

Please take a look of this error, thanks.